### PR TITLE
Use LTS with Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "7"
+  - "lts/*"


### PR DESCRIPTION
Update node version used by Travis.  This was causing recent tests to fail after updating some 3rd party dependencies.